### PR TITLE
Added support for grayscale PSFs in io.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 #### Bugfix
 
--
+- Loading grayscale PSFs would cause an dimension error when removing the background pixels
 
 ## 1.0.2 - (2022-05-31)
 

--- a/lensless/io.py
+++ b/lensless/io.py
@@ -9,16 +9,16 @@ from lensless.constants import RPI_HQ_CAMERA_CCM_MATRIX, RPI_HQ_CAMERA_BLACK_LEV
 
 
 def load_image(
-        fp,
-        verbose=False,
-        flip=False,
-        bayer=False,
-        black_level=RPI_HQ_CAMERA_BLACK_LEVEL,
-        blue_gain=None,
-        red_gain=None,
-        ccm=RPI_HQ_CAMERA_CCM_MATRIX,
-        back=None,
-        nbits_out=None,
+    fp,
+    verbose=False,
+    flip=False,
+    bayer=False,
+    black_level=RPI_HQ_CAMERA_BLACK_LEVEL,
+    blue_gain=None,
+    red_gain=None,
+    ccm=RPI_HQ_CAMERA_CCM_MATRIX,
+    back=None,
+    nbits_out=None,
 ):
     """
     Load image as numpy array.
@@ -103,20 +103,20 @@ def load_image(
 
 
 def load_psf(
-        fp,
-        downsample=1,
-        return_float=True,
-        bg_pix=(5, 25),
-        return_bg=False,
-        flip=False,
-        verbose=False,
-        bayer=False,
-        blue_gain=None,
-        red_gain=None,
-        dtype=np.float32,
-        nbits_out=None,
-        single_psf=False,
-        shape=None,
+    fp,
+    downsample=1,
+    return_float=True,
+    bg_pix=(5, 25),
+    return_bg=False,
+    flip=False,
+    verbose=False,
+    bayer=False,
+    blue_gain=None,
+    red_gain=None,
+    dtype=np.float32,
+    nbits_out=None,
+    single_psf=False,
+    shape=None,
 ):
     """
     Load and process PSF for analysis or for reconstruction.
@@ -231,20 +231,20 @@ def load_psf(
 
 
 def load_data(
-        psf_fp,
-        data_fp,
-        downsample=None,
-        bg_pix=(5, 25),
-        plot=True,
-        flip=False,
-        bayer=False,
-        blue_gain=None,
-        red_gain=None,
-        gamma=None,
-        gray=False,
-        dtype=np.float32,
-        single_psf=False,
-        shape=None,
+    psf_fp,
+    data_fp,
+    downsample=None,
+    bg_pix=(5, 25),
+    plot=True,
+    flip=False,
+    bayer=False,
+    blue_gain=None,
+    red_gain=None,
+    gamma=None,
+    gray=False,
+    dtype=np.float32,
+    single_psf=False,
+    shape=None,
 ):
     """
     Load data for image reconstruction.

--- a/lensless/io.py
+++ b/lensless/io.py
@@ -187,14 +187,14 @@ def load_psf(
     else:
         # grayscale
         if len(np.shape(psf)) < 3:
-            bg = np.mean(psf[bg_pix[0]: bg_pix[1], bg_pix[0]: bg_pix[1]])
+            bg = np.mean(psf[bg_pix[0] : bg_pix[1], bg_pix[0] : bg_pix[1]])
             psf -= bg
 
         # rgb
         else:
             bg = []
             for i in range(3):
-                bg_i = np.mean(psf[bg_pix[0]: bg_pix[1], bg_pix[0]: bg_pix[1], i])
+                bg_i = np.mean(psf[bg_pix[0] : bg_pix[1], bg_pix[0] : bg_pix[1], i])
                 psf[:, :, i] -= bg_i
                 bg.append(bg_i)
 
@@ -208,7 +208,7 @@ def load_psf(
         psf = resize(psf, factor=1 / downsample)
 
     if single_psf:
-        if(len(psf.shape) == 3):
+        if len(psf.shape) == 3:
             # TODO : in Lensless Learning, they sum channels --> `psf_diffuser = np.sum(psf_diffuser,2)`
             # https://github.com/Waller-Lab/LenslessLearning/blob/master/pre-trained%20reconstructions.ipynb
             psf = np.sum(psf, 2)

--- a/lensless/metric.py
+++ b/lensless/metric.py
@@ -72,8 +72,8 @@ def ssim(true, est, normalize=True, channel_axis=2, **kwargs):
     normalize : bool, optional
         Whether to normalize such that maximum value is 1.
     channel_axis : int or None, optional
-        If `None`, the image is assumed to be a grayscale (single channel) image. 
-        Otherwise, this parameter indicates which axis of the array corresponds 
+        If `None`, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
         to channels.
 
     Returns


### PR DESCRIPTION
When loading the psf in io.py/load_psf, it is not checked if the psf is rgb or grayscale when substracting background pixels, and all psf are treated as rgb, causing an error with grayscale psf. I propose a fix to this issue. 