### PR TITLE
Better ploting for benchmark result

### DIFF
--- a/scripts/eval/benchmark_recon.py
+++ b/scripts/eval/benchmark_recon.py
@@ -189,10 +189,11 @@ def benchmark_recon(config):
                         marker="o",
                         color=color,
                     )
-        plt.title(metric)
-        plt.xlabel("Number of iterations")
-        plt.ylabel(metric)
-        plt.legend(fontsize="8")
+        plt.xlabel("Number of iterations", fontsize="12")
+        plt.ylabel(metric, fontsize="12")
+        if metric == "ReconstructionError":
+            plt.legend(fontsize="12")
+        plt.grid()
         plt.savefig(f"{metric}.png")
 
 


### PR DESCRIPTION
Small change to the plotting at the end of `benchmark_recon.py` to make the plot more readable. As of now the legend is only plotted on the reconstruction error graph. But I can but it everywhere if it is preferred.

Thank you for submitting a pull request (PR)! Before hitting the submit button, we would be really glad if you check all the following points. Even if you can't check all the boxes below, do not hesitate to go ahead with the PR and ask for help there.

Please also refer to the doc on [contributing](https://lensless.readthedocs.io/en/latest/contributing.html) for more details. 

- [x] Have you run the tests by running `pytest` from the repository root? See the [documentation](https://lensless.readthedocs.io/en/latest/contributing.html#unit-tests) for more details.
- [ ] Do you follow the code formatting for this project? This can be done by setting up pre-commit hooks as described in the [documentation](https://lensless.readthedocs.io/en/latest/contributing.html#coding-style).
- [ ] Is there a unit test for the proposed code modification? If the PR addresses an issue, the test should make sure the issue is fixed.
- [x] Are there docstrings? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style?
- [x] Have you checked that the doc builds properly and that any new RST file has been added to the repo? How to do that is covered in the [documentation](https://lensless.readthedocs.io/en/latest/contributing.html#building-documentation).
- [ ] Did you document the proposed change(s) in the CHANGELOG file? It should go under "Unreleased".

Happy PR :smiley: