### PR TITLE
Add load_pretrained to unrolledADMMM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ DiffuserCam_Mirflickr_200_3011302021_11h43_seed11*
 paper/paper.pdf
 data/*
 models/*
+pretrained_models/*
+
 *.png
 *.jpg
 *.npy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Added
 - Support for unrolled loading and inference in the script ``admm.py``.
 - Tikhonov reconstruction for coded aperture measurements (MLS / MURA).
 - New ``Trainer`` class to train ``TrainableReconstructionAlgorithm`` with PyTorch.
+- New ``load_pretrained`` to load pretrained unrolled_admm model.
 
 
 Changed

--- a/configs/defaults_recon.yaml
+++ b/configs/defaults_recon.yaml
@@ -62,8 +62,14 @@ admm:
   mu2: 1e-5
   mu3: 4e-5
   tau: 0.0001
-  #Loading unrolled model
-  unrolled: false
+  # Loading unrolled model
+  unrolled: False
+  # Use pre-trained model otehrwise will load from checkpoint_fp
+  pre_trained: True
+  # Pre-trained model information
+  pre_trained_name: "Best"  # "Best", "Unrolled", "Pre_Unrolled", "Unrolled_Post", "Pre_Unrolled_Post"
+  pre_trained_psf: "DiffuserCam"
+  #custom checkpoint file path and architecture
   checkpoint_fp: null
   pre_process_model: 
     network : null  # UnetRes or DruNet or null

--- a/docs/source/reconstruction.rst
+++ b/docs/source/reconstruction.rst
@@ -86,7 +86,7 @@
    ~~~~~~~~~~~~~
 
    .. autoclass:: lensless.UnrolledADMM
-      :members: batch_call
+      :members: batch_call, load_pretrained
       :special-members: __init__
       :show-inheritance:
 

--- a/lensless/recon/recon.py
+++ b/lensless/recon/recon.py
@@ -426,7 +426,7 @@ class ReconstructionAlgorithm(abc.ABC):
             Extracted data.
         """
         if self.is_torch:
-            return data.detach().cpu().numpy()
+            return data.detach().cpu().squeeze().numpy()
         else:
             return data
 

--- a/lensless/recon/trainable_recon.py
+++ b/lensless/recon/trainable_recon.py
@@ -5,7 +5,10 @@
 # Yohann PERRON [yohann.perron@gmail.com]
 # #############################################################################
 
+import matplotlib.pyplot as plt
+import pathlib as plib
 from lensless.recon.recon import ReconstructionAlgorithm
+from lensless.utils.plot import plot_image
 
 try:
     import torch
@@ -203,7 +206,17 @@ class TrainableReconstructionAlgorithm(ReconstructionAlgorithm, torch.nn.Module)
         )
         if self.post_process is not None:
             if isinstance(im, tuple):
-                im = self.post_process(im[0], self.post_process_param), im[1]
+                im = self.post_process(im[0], self.post_process_param)
             else:
                 im = self.post_process(im, self.post_process_param)
+
+            if plot:
+                ax = plot_image(img=self._get_numpy_data(im), gamma=gamma)
+                ax.set_title(
+                    "Final reconstruction after {} iterations and post process".format(self._n_iter)
+                )
+                if save:
+                    plt.savefig(plib.Path(save) / "final.png")
+                return im, ax
+
         return im

--- a/lensless/recon/trainable_recon.py
+++ b/lensless/recon/trainable_recon.py
@@ -202,5 +202,8 @@ class TrainableReconstructionAlgorithm(ReconstructionAlgorithm, torch.nn.Module)
             reset=reset,
         )
         if self.post_process is not None:
-            im = self.post_process(im, self.post_process_param)
+            if isinstance(im, tuple):
+                im = self.post_process(im[0], self.post_process_param), im[1]
+            else:
+                im = self.post_process(im, self.post_process_param)
         return im

--- a/lensless/recon/unrolled_admm.py
+++ b/lensless/recon/unrolled_admm.py
@@ -245,7 +245,7 @@ class UnrolledADMM(TrainableReconstructionAlgorithm):
 
         # create path to models
         if path_to_models is None:
-            path_to_models = os.path.join(os.getcwd(), "pretrain_models")
+            path_to_models = os.path.join(os.getcwd(), "pretrained_models")
 
         if not os.path.exists(path_to_models):
             os.makedirs(path_to_models)

--- a/lensless/recon/unrolled_admm.py
+++ b/lensless/recon/unrolled_admm.py
@@ -259,8 +259,17 @@ class UnrolledADMM(TrainableReconstructionAlgorithm):
 
         # check if model is already downloaded
         if not os.path.exists(os.path.join(path_to_models, model_dir)):
+            from torchvision.datasets.utils import download_and_extract_archive
+
             # download model
-            raise NotImplementedError("Model not found. Automatic download not implemented.")
+            filename = model_dir + ".zip"
+            url = (
+                "https://drive.switch.ch/index.php/s/JTJSNm0F4l0sJo7/download?path=%2Fmodels%2Fpretrain_models&files="
+                + filename
+            )
+            download_and_extract_archive(
+                url, path_to_models, filename=filename, remove_finished=True
+            )
 
         # load model parameters from json file
         with open(os.path.join(path_to_models, model_dir, "model_params.yaml")) as yaml_file:
@@ -315,10 +324,3 @@ class UnrolledADMM(TrainableReconstructionAlgorithm):
         )
 
         return model
-
-
-Pretrain_model_ADMM = Enum(
-    "Pretrain_model_ADMM",
-    ["Best", "Unrolled", "Pre_Unrolled", "Unrolled_Post", "Pre_Unrolled_Post"],
-)
-Pretrain_Dataset = Enum("Pretrain_Dataset_ADMM", ["DiffuserCam"])

--- a/lensless/recon/unrolled_admm.py
+++ b/lensless/recon/unrolled_admm.py
@@ -269,7 +269,7 @@ class UnrolledADMM(TrainableReconstructionAlgorithm):
             # download model
             filename = model_dir + ".zip"
             url = (
-                "https://drive.switch.ch/index.php/s/JTJSNm0F4l0sJo7/download?path=%2Fmodels%2Fpretrain_models&files="
+                "https://drive.switch.ch/index.php/s/EiWlwOIKjn1prpr/download?path=%2F&files="
                 + filename
             )
             download_and_extract_archive(

--- a/lensless/recon/unrolled_admm.py
+++ b/lensless/recon/unrolled_admm.py
@@ -242,10 +242,14 @@ class UnrolledADMM(TrainableReconstructionAlgorithm):
         import yaml
         from lensless.utils.io import load_psf
         from lensless.recon.utils import create_process_network
+        from hydra.utils import get_original_cwd
 
         # create path to models
         if path_to_models is None:
-            path_to_models = os.path.join(os.getcwd(), "pretrained_models")
+            try:
+                path_to_models = os.path.join(get_original_cwd(), "pretrained_models")
+            except ValueError:
+                path_to_models = os.path.join(os.getcwd(), "pretrained_models")
 
         if not os.path.exists(path_to_models):
             os.makedirs(path_to_models)
@@ -259,6 +263,7 @@ class UnrolledADMM(TrainableReconstructionAlgorithm):
 
         # check if model is already downloaded
         if not os.path.exists(os.path.join(path_to_models, model_dir)):
+            print(os.path.join(path_to_models, model_dir))
             from torchvision.datasets.utils import download_and_extract_archive
 
             # download model

--- a/lensless/recon/utils.py
+++ b/lensless/recon/utils.py
@@ -191,8 +191,14 @@ def create_process_network(network, depth, device="cpu"):
     if network == "DruNet":
         from lensless.recon.utils import load_drunet
 
+        try:
+            base_path = get_original_cwd()
+        except ValueError:
+            # if not in hydra environement
+            base_path = os.getcwd()
+
         process = load_drunet(
-            os.path.join(get_original_cwd(), "data/drunet_color.pth"), requires_grad=True
+            os.path.join(base_path, "data/drunet_color.pth"), requires_grad=True
         ).to(device)
         process_name = "DruNet"
     elif network == "UnetRes":

--- a/lensless/utils/io.py
+++ b/lensless/utils/io.py
@@ -32,6 +32,7 @@ def load_image(
     downsample=None,
     bg=None,
     return_float=False,
+    normalize=True,
     shape=None,
     dtype=None,
 ):
@@ -69,6 +70,8 @@ def load_image(
         Background level to subtract.
     return_float : bool
         Whether to return image as float array, or unsigned int.
+    normalize : bool, optional
+        Whether to normalize image to [0, 1]. Default is True.
     shape : tuple, optional
         Shape (H, W, C) to resize to.
     dtype : str, optional
@@ -159,7 +162,8 @@ def load_image(
             dtype = np.float32
         assert dtype == np.float32 or dtype == np.float64
         img = img.astype(dtype)
-        img /= img.max()
+        if normalize:
+            img /= img.max()
 
     else:
         if dtype is None:
@@ -349,6 +353,7 @@ def load_data(
     shape=None,
     torch=False,
     torch_device="cpu",
+    normalize_data=True,
 ):
     """
     Load data for image reconstruction.
@@ -385,6 +390,8 @@ def load_data(
         Whether to sum RGB channels into single PSF, same across channels. Done
         in "Learned reconstructions for practical mask-based lensless imaging"
         of Kristina Monakhova et. al.
+    normalize_data : bool
+        Whether to normalize data to [0, 1].
 
     Returns
     -------
@@ -438,6 +445,7 @@ def load_data(
         as_4d=True,
         return_float=True,
         shape=shape,
+        normalize=normalize_data,
     )
 
     if data.shape != psf.shape:

--- a/lensless/utils/io.py
+++ b/lensless/utils/io.py
@@ -134,9 +134,8 @@ def load_image(
         print_image_info(img)
 
     if bg is not None:
-
-        # if bg is float vector, turn into int-valued vector
-        if bg.max() <= 1:
+        # if bg is float vector and image is int, turn bg into int-valued vector
+        if bg.max() <= 1 and img.max() > 1:
             bg = bg * get_max_val(img)
 
         img = img - bg

--- a/scripts/recon/admm.py
+++ b/scripts/recon/admm.py
@@ -42,6 +42,7 @@ def admm(config):
         torch=config.torch,
         torch_device=config.torch_device,
         bg_pix=config.preprocess.bg_pix,
+        normalize_data=not config.admm.unrolled,
     )
 
     disp = config["display"]["disp"]
@@ -86,6 +87,7 @@ def admm(config):
         print("Loading checkpoint from : ", path)
         assert os.path.exists(path), "Checkpoint does not exist"
         recon.load_state_dict(torch.load(path, map_location=config.torch_device))
+
     recon.set_data(data)
     print(f"Setup time : {time.time() - start_time} s")
 

--- a/scripts/recon/admm.py
+++ b/scripts/recon/admm.py
@@ -54,8 +54,18 @@ def admm(config):
 
     start_time = time.time()
     if not config.admm.unrolled:
+        # Normal ADMM
         recon = ADMM(psf, **config.admm)
+    elif config.admm.pre_trained:
+        assert config.torch, "Unrolled ADMM only works with torch"
+        from lensless.recon.unrolled_admm import UnrolledADMM
+
+        # load from pre-trained checkpoint
+        recon = UnrolledADMM.load_pretrained(
+            config.admm.pre_trained_name, config.admm.pre_trained_psf, device=config.torch_device
+        )
     else:
+        # load from custom checkpoint
         assert config.torch, "Unrolled ADMM only works with torch"
         from lensless.recon.unrolled_admm import UnrolledADMM
         import lensless.recon.utils


### PR DESCRIPTION
Add a function to automatically load a pretrained model:

- [x] Add pretrained models to cloud
- [x] Add auto download from cloud
   - [x] New read only without password link
   - [x] change link in autodownload code

Please also refer to the doc on [contributing](https://lensless.readthedocs.io/en/latest/contributing.html) for more details. 

- [x] Have you run the tests by running `pytest` from the repository root? See the [documentation](https://lensless.readthedocs.io/en/latest/contributing.html#unit-tests) for more details.
- [x] Do you follow the code formatting for this project? This can be done by setting up pre-commit hooks as described in the [documentation](https://lensless.readthedocs.io/en/latest/contributing.html#coding-style).
- [ ] Is there a unit test for the proposed code modification? If the PR addresses an issue, the test should make sure the issue is fixed.
- [x] Are there docstrings? Do they follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) style?
- [x] Have you checked that the doc builds properly and that any new RST file has been added to the repo? How to do that is covered in the [documentation](https://lensless.readthedocs.io/en/latest/contributing.html#building-documentation).
- [ ] Did you document the proposed change(s) in the CHANGELOG file? It should go under "Unreleased".

Happy PR :smiley: