### PR TITLE
Fix silent uint8 overflow

### DIFF
--- a/scripts/measure/prep_display_image.py
+++ b/scripts/measure/prep_display_image.py
@@ -165,7 +165,7 @@ def display(
         img = np.roll(img, shift=int(hshift * ny / 100), axis=1)
 
     if brightness:
-        img = (img * brightness / 100).astype(np.uint8)
+        img = (img.astype(np.float32) * brightness / 100).astype(np.uint8)
 
     # save to file
     im = Image.fromarray(img)


### PR DESCRIPTION
Previous version of code used `img` with `np.uint8` dtype, which silently caused `uint8` overflow when `brightness` was passed as integer instead of float. 

```
if brightness:
        img = (img * brightness / 100).astype(np.uint8)
```

This PR fixes this issue by explicitly converting `img` to `np.float32` before the multiplication.